### PR TITLE
Add lvm bytes conversion (which is integer multiple of PE size) in volume expansion

### DIFF
--- a/pkg/member/node/storage/validator.go
+++ b/pkg/member/node/storage/validator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	localstoragev1alpha1 "github.com/hwameistor/local-storage/pkg/apis/localstorage/v1alpha1"
+	"github.com/hwameistor/local-storage/pkg/utils"
 )
 
 type validator struct{}
@@ -93,7 +94,7 @@ func (cr *validator) checkPoolVolumeCount(vr *localstoragev1alpha1.LocalVolumeRe
 func (cr *validator) checkPoolCapacity(vr *localstoragev1alpha1.LocalVolumeReplica, reg LocalRegistry) error {
 	pools := reg.Pools()
 	if pool, has := pools[vr.Spec.PoolName]; has {
-		if pool.FreeCapacityBytes < numericToLVMBytes(vr.Spec.RequiredCapacityBytes) {
+		if pool.FreeCapacityBytes < utils.NumericToLVMBytes(vr.Spec.RequiredCapacityBytes) {
 			return ErrorInsufficientRequestResources
 		}
 	} else {
@@ -105,7 +106,7 @@ func (cr *validator) checkPoolCapacity(vr *localstoragev1alpha1.LocalVolumeRepli
 func (cr *validator) checkPerVolumeCapacityLimit(vr *localstoragev1alpha1.LocalVolumeReplica, reg LocalRegistry) error {
 	pools := reg.Pools()
 	if pool, has := pools[vr.Spec.PoolName]; has {
-		if pool.VolumeCapacityBytesLimit < numericToLVMBytes(vr.Spec.RequiredCapacityBytes) {
+		if pool.VolumeCapacityBytesLimit < utils.NumericToLVMBytes(vr.Spec.RequiredCapacityBytes) {
 			return ErrorOverLimitedRequestResource
 		}
 	} else {

--- a/pkg/utils/lvm_utils.go
+++ b/pkg/utils/lvm_utils.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"errors"
+	"strconv"
+)
+
+var (
+	ErrNotLVMByteNum = errors.New("LVM byte format unrecognised")
+)
+
+func ConvertLVMBytesToNumeric(lvmbyte string) (int64, error) {
+	if len(lvmbyte) == 0 || lvmbyte[len(lvmbyte)-1] != 'B' {
+		return 0, ErrNotLVMByteNum
+	}
+	num, err := strconv.Atoi(lvmbyte[:len(lvmbyte)-1])
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(num), nil
+}
+
+func ConvertNumericToLVMBytes(num int64) string {
+	lvmSizeInBytes := NumericToLVMBytes(num)
+	return strconv.Itoa(int(lvmSizeInBytes)) + "B"
+}
+
+func NumericToLVMBytes(bytes int64) int64 {
+	peSize := int64(4 * 1024 * 1024)
+	if bytes <= peSize {
+		return peSize
+	}
+	if bytes%peSize == 0 {
+		return bytes
+	}
+	return (bytes/peSize + 1) * peSize
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### Why we need this PR:

Since LVM can only receive integer multiple of PE size (default is 4MiB).
Add lvm bytes conversion (which is integer multiple of PE size) in volume expansion

#### Before this PR:
we converted required capacity bytes in both create and resize lvs. SEE:
https://github.com/hwameistor/local-storage/blob/312ae69108e431418b17640dfc136d7d758323a7/pkg/member/node/storage/executor_lvm.go#L298


But when judge if a resize job was done. we compare origin capacity bytes with converted capacity bytes which might never equal occasionally, depending if the required capacity bytes is integer multiple of PE size. SEE: 
https://github.com/hwameistor/local-storage/blob/312ae69108e431418b17640dfc136d7d758323a7/pkg/member/controller/volume_expand_task_worker.go#L109-L110

#### Special notes for your reviewer:
```
None
```
#### Does this PR introduce a user-facing change?
```release-note
None
```
