### PR TITLE
fix: del --scheduler-name=hwameistor-scheduler in 07_scheduler.yaml

### DIFF
--- a/deploy/07_scheduler.yaml
+++ b/deploy/07_scheduler.yaml
@@ -51,7 +51,6 @@ spec:
         - -v=2
         - --bind-address=0.0.0.0
         - --kubeconfig=/etc/kubernetes/scheduler.conf
-        - --scheduler-name=hwameistor-scheduler
         - --leader-elect=false
         - --leader-elect-resource-name=hwameistor-scheduler
         - --config=/etc/hwameistor/scheduler-config.yaml


### PR DESCRIPTION
Signed-off-by: jie.li <jie.li@daocloud.io>

<!--  Thanks for sending a pull request! -->

#### Why we need this PR:
fix: del --scheduler-name=hwameistor-scheduler in 07_scheduler.yaml
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```
