### PR TITLE
sanitizes the hostname so it can be consumed by leader election library

### DIFF
--- a/pkg/member/controller/node_status.go
+++ b/pkg/member/controller/node_status.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hwameistor/local-storage/pkg/apis"
 	apisv1alpha1 "github.com/hwameistor/local-storage/pkg/apis/hwameistor/v1alpha1"
+	"github.com/hwameistor/local-storage/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	log "github.com/sirupsen/logrus"
@@ -64,7 +65,8 @@ func (m *manager) syncNodesStatus() {
 
 	currTime := time.Now()
 	for _, node := range nodeList.Items {
-		lease, ok := nodeLeases[node.Name]
+		sanitizedNodeName := utils.SanitizeName(node.Name)
+		lease, ok := nodeLeases[sanitizedNodeName]
 		if !ok {
 			// no lease, should set node offline
 			m.setNodeState(ctx, &node, apisv1alpha1.NodeStateOffline)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### Why we need this PR:
```
We should support hostname like "abc.def". For now if LS meet hostname contents '.' LSN will stuck with state 'offline'.
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```
