### PR TITLE
UT: update unit-test coverage packages filter out third-party pakcages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ clean:
 	docker rmi -f $(shell docker images -f dangling=true -qa)
 
 unit-test:
-	go test -race -coverprofile=coverage.txt -covermode=atomic ./pkg/...
+	go test -race -coverprofile=coverage.txt -covermode=atomic ./pkg/member/... ./pkg/controller/... ./pkg/utils/...
 	curl -s https://codecov.io/bash | bash
 
 e2e-test:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### Why we need this PR:
update unit-test coverage packages filter out third-party pakcages
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
